### PR TITLE
Staged docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 build
-out
+bin
 svgout
 vendor
 .*.sw*

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 services:
   - docker
 script:
-  - make docker-cflakes-build docker-cflakes
+  - docker build -t epilanthanomai/cflakes .
 deploy:
   provider: script
   script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,14 @@ sudo: required
 services:
   - docker
 script:
-  - docker build -t epilanthanomai/cflakes .
+  - docker build -t cflakes .
 deploy:
   provider: script
   script:
     - docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD";
-      docker push epilanthanomai/cflakes
+      docker tag cflakes epilanthanomai/cflakes:latest;
+      docker push epilanthanomai/cflakes:latest;
+      docker tag cflakes "epilanthanomai/cflakes:${JENKINS_TAG#v}";
+      docker push "epilanthanomai/cflakes:${JENKINS_TAG#v}"
   on:
-    branch:
-      - develop
+    tags: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM alpine:3.8 AS builder
+ENV ROOT /opt/cflakes
+WORKDIR $ROOT
+RUN apk update &&\
+    apk add --update \
+      build-base \
+      curl \
+      docker
+COPY . $ROOT
+RUN make
+
+FROM alpine:3.8
+ENV ROOT /opt/cflakes
+WORKDIR $ROOT
+COPY --from=builder $ROOT/bin/cflakes bin/cflakes
+CMD ["bin/cflakes"]

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@ SRCDIR=src
 BUILDDIR=build
 BINDIR=bin
 VENDORDIR=vendor
-DOCKERDIR=docker
 
 UTHASH_VERSION=2.0.2
 
@@ -11,12 +10,6 @@ CFLAGS.errors=-Wall -Werror
 CFLAGS.deps=-MD -MF$(patsubst %.o,%.d,$@)
 CFLAGS.includes=-I$(VENDORDIR)/uthash-$(UTHASH_VERSION)/src
 CFLAGS=$(CFLAGS.base) $(CFLAGS.errors) $(CFLAGS.deps) $(CFLAGS.includes)
-
-DOCKER_APP_HOME=/opt/cflakes
-DOCKER_SOCK=/var/run/docker.sock
-DOCKER_RUN_VOLUMES=-v `pwd`:$(DOCKER_APP_HOME) -v $(DOCKER_SOCK):$(DOCKER_SOCK)
-DOCKER_IMAGE_BUILD=cflakes-build
-DOCKER_IMAGE_CFLAKES=epilanthanomai/cflakes
 
 # main targets
 
@@ -43,19 +36,6 @@ $(VENDORDIR)/uthash-$(UTHASH_VERSION)/%: $(VENDORDIR)/uthash-$(UTHASH_VERSION).t
 
 $(VENDORDIR)/uthash-$(UTHASH_VERSION).tar.gz:
 	curl -Lo $@ https://github.com/troydhanson/uthash/archive/v$(UTHASH_VERSION).tar.gz
-
-# docker targets
-.PHONY: docker-cflakes-build
-docker-cflakes-build:
-	docker build -f $(DOCKERDIR)/build.Dockerfile -t $(DOCKER_IMAGE_BUILD) .
-
-.PHONY: docker-cflakes
-docker-cflakes:
-	docker run --rm $(DOCKER_RUN_VOLUMES) $(DOCKER_IMAGE_BUILD) sh -c 'cd $(DOCKER_APP_HOME) && make docker-cflakes-nested'
-
-.PHONY: docker-cflakes-nested
-docker-cflakes-nested: $(BINDIR)/cflakes
-	docker build -f $(DOCKERDIR)/cflakes.Dockerfile -t $(DOCKER_IMAGE_CFLAKES) .
 
 # utility targets
 

--- a/docker/build.Dockerfile
+++ b/docker/build.Dockerfile
@@ -1,6 +1,0 @@
-FROM alpine:3.8
-RUN apk update &&\
-    apk add --update \
-      build-base \
-      curl \
-      docker

--- a/docker/cflakes.Dockerfile
+++ b/docker/cflakes.Dockerfile
@@ -1,5 +1,0 @@
-FROM alpine:3.8
-ENV ROOT /opt/cflakes
-WORKDIR $ROOT
-COPY bin/cflakes $ROOT/bin/cflakes
-CMD $ROOT/bin/cflakes


### PR DESCRIPTION
Use staged docker builds, which lets us simplify a lot of our docker build logic.

Also forward git tag through jenkins to the docker hub image tag, and only deploy to hub for tags